### PR TITLE
Remove dependency on `unstable/socket`

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -1,7 +1,7 @@
 #lang setup/infotab
 
 (define collection 'multi)
-(define deps '("base" "scribble-lib" "misc1"))
-(define build-deps '("racket-doc" "unstable-doc"))
+(define deps '("base" "scribble-lib" "misc1" "unix-socket-lib"))
+(define build-deps '("racket-doc" "unstable-doc" "unix-socket-doc"))
 
 ; vim:set ts=2 sw=2 et:

--- a/multipath-daemon/main.rkt
+++ b/multipath-daemon/main.rkt
@@ -7,7 +7,7 @@
          racket/string
          racket/format
          racket/class
-         unstable/socket)
+         racket/unix-socket)
 
 (require misc1/throw)
 

--- a/multipath-daemon/multipath-daemon.scrbl
+++ b/multipath-daemon/multipath-daemon.scrbl
@@ -2,7 +2,7 @@
 
 @require[(for-label multipath-daemon)
          (for-label racket)
-         (for-label unstable/socket)]
+         (for-label racket/unix-socket)]
 
 @title{Multipath Daemon API}
 @author+email["Jan Dvorak" "mordae@anilinux.org"]


### PR DESCRIPTION
The functionality of that library has been moved to `racket/unix-socket` (package `unix-socket-lib`), and `unstable/socket` will be removed from the main distribution.

This PR makes this package incompatible with Racket 6.2.1. To preserve compatibility, you can create a Racket 6.2-compatible branch in this repository and set up a version exception at pkgs.racket-lang.org

Even without the changes from this PR, this package will continue to work with future versions of Racket. It will, however, require installation of the `unstable-lib` package, as it will not be part of the main distribution in future versions. If you decide to go with that option, please add a dependency to `unstable-lib`.
